### PR TITLE
Fix Player Position Labels

### DIFF
--- a/FootballBlazorApp/Components/Squad.razor
+++ b/FootballBlazorApp/Components/Squad.razor
@@ -36,9 +36,6 @@
 
     private string GetPositionLabel(string position) => $"{position}s";
 
-    private string GetCoachingRoleLabel(Enums.SquadRole coachingRole) =>
-                                coachingRole.ToString().Replace("_", " ");
-
     private List<Player> GetPlayersOrderedByName(List<Player> players)
     {
         return players.OrderBy(x => x.Name).ToList();

--- a/FootballEngine/Logic/TeamLogic.cs
+++ b/FootballEngine/Logic/TeamLogic.cs
@@ -36,7 +36,7 @@ namespace FootballEngine.Services
                             HomeStadium = x.venue,
                             Squad = x.squad
                                     .ToList()
-                                    .Select(x => GetPlayerFromSquad(x))
+                                    .Select(y => GetPlayerFromSquad(y, x.id))
                                     .ToList(),
                             Coach = new FootballShared.Models.Coach() { 
                                 CoachID = x.coach.id,
@@ -62,7 +62,7 @@ namespace FootballEngine.Services
                     .GroupBy(x => x.Position)
                     .Select(x => new PlayerByPosition()
                     {
-                        Position = x.Key,
+                        Position = TidySquadPosition(x.Key),
                         SortOrder = GetSquadSortOrder(x.Key),
                         Players = x.ToList(),
                     })
@@ -70,7 +70,7 @@ namespace FootballEngine.Services
                     .ToList();
         }
 
-        private Player GetPlayerFromSquad(Squad squad)
+        private Player GetPlayerFromSquad(Squad squad, int TeamID)
         {
             return new Player()
             {
@@ -80,6 +80,7 @@ namespace FootballEngine.Services
                 DateOfBirth = squad.dateOfBirth,
                 Nationality = squad.nationality,
                 Age = CalculateAge(squad.dateOfBirth),
+                TeamID = TeamID,
             };
         }
 
@@ -93,6 +94,33 @@ namespace FootballEngine.Services
                                 : age;
         }
 
+        private string TidySquadPosition(string position)
+        {
+            string tidySquadPosition = string.Empty;
+
+            string positionForDisplay = position.Replace("_", " ");
+
+            switch (positionForDisplay)
+            {
+                case "Goalkeeper":
+                    tidySquadPosition = PlayerPosition.Goalkeeper.ToString();
+                    break;
+                case "Defence":
+                    tidySquadPosition = PlayerPosition.Defender.ToString();
+                    break;
+                case "Midfield":
+                    tidySquadPosition = PlayerPosition.Midfielder.ToString();
+                    break;
+                case "Offence":
+                    tidySquadPosition = PlayerPosition.Attacker.ToString();
+                    break;
+                default:
+                    break;
+            }
+
+            return tidySquadPosition;
+        }
+
         private int GetSquadSortOrder(string position)
         {
             int squadSortOrder = (int)PlayerPosition.Goalkeeper;
@@ -104,13 +132,13 @@ namespace FootballEngine.Services
                 case "Goalkeeper":
                     squadSortOrder = (int)PlayerPosition.Goalkeeper;
                     break;
-                case "Defender":
+                case "Defence":
                     squadSortOrder = (int)PlayerPosition.Defender;
                     break;
-                case "Midfielder":
+                case "Midfield":
                     squadSortOrder = (int)PlayerPosition.Midfielder;
                     break;
-                case "Attacker":
+                case "Offence":
                     squadSortOrder = (int)PlayerPosition.Attacker;
                     break;
                 default:

--- a/FootballEngine/Services/FootballDataService.cs
+++ b/FootballEngine/Services/FootballDataService.cs
@@ -87,6 +87,11 @@ namespace FootballEngine.Services
 
         public async Task<List<GroupOrLeagueTableModel>> GetFixturesAndResultsByGroupsAsync(List<GroupOrLeagueTableModel> groupsOrLeagueTable)
         {
+            if (!groupsOrLeagueTable?.FirstOrDefault().IsGroup ?? false)
+            {
+                return groupsOrLeagueTable;
+            }
+
             var footballDataMatches = await GetFootballDataMatchesAsync();
 
             var fixtureAndResultLogic = new FixtureAndResultLogic(footballDataMatches, _footballEngineInput);

--- a/FootballUnitTest/FootballDataServiceTest.cs
+++ b/FootballUnitTest/FootballDataServiceTest.cs
@@ -29408,7 +29408,7 @@ namespace FootballEngineUnitTest
         public class GetGroupsOrLeagueTableAsync : FootballDataServiceTest
         {
             [TestMethod]
-            public async Task WhenGroupsOrLeagueTableFootballDataNeverCached_ThenStandingsAndMatchesReturnedFromAPIAndCacheRefreshed()
+            public async Task WhenGroupsOrLeagueTableFootballDataNeverCachedAndCompetitionDoesNotUseGroups_ThenStandingsReturnedFromAPIAndCacheRefreshed()
             {
                 SetupTests();
 
@@ -29423,34 +29423,7 @@ namespace FootballEngineUnitTest
                 var firstGroupOrLeagueTable = groupsOrLeagueTable.FirstOrDefault();
 
                 mockHttpAPIClient.Verify(mock => mock.GetAsync($"competitions/{footballEngineInput.Competition}/standings/"), Times.Once());
-                mockHttpAPIClient.Verify(mock => mock.GetAsync($"competitions/{footballEngineInput.Competition}/matches/"), Times.Once());
-
-                Assert.IsNotNull(firstGroupOrLeagueTable);
-                Assert.AreEqual("Premier League Table", firstGroupOrLeagueTable.Name);
-                Assert.AreEqual(20, firstGroupOrLeagueTable.GroupOrLeagueTableStandings.Count);
-                Assert.IsTrue(footballDataState.IsCacheRefreshed);
-            }
-
-            [TestMethod]
-            public async Task WhenGroupsOrLeagueTableFootballDataNotNullButFootballDataStandingsIsNull_ThenStandingsAndMatchesReturnedFromAPIAndCacheRefreshed()
-            {
-                SetupTests();
-
-                footballDataState = new FootballDataState()
-                {
-                    FootballDataStandings = null,
-                };
-
-                var footballDataService = new FootballDataService(mockHttpAPIClient.Object, footballDataState, footballEngineInput);
-
-                var groupsOrLeagueTable = await footballDataService.GetGroupsOrLeagueTableAsync();
-
-                Assert.IsNotNull(groupsOrLeagueTable);
-
-                var firstGroupOrLeagueTable = groupsOrLeagueTable.FirstOrDefault();
-
-                mockHttpAPIClient.Verify(mock => mock.GetAsync($"competitions/{footballEngineInput.Competition}/standings/"), Times.Once());
-                mockHttpAPIClient.Verify(mock => mock.GetAsync($"competitions/{footballEngineInput.Competition}/matches/"), Times.Once());
+                mockHttpAPIClient.Verify(mock => mock.GetAsync($"competitions/{footballEngineInput.Competition}/matches/"), Times.Never());
 
                 Assert.IsNotNull(firstGroupOrLeagueTable);
                 Assert.AreEqual("Premier League Table", firstGroupOrLeagueTable.Name);
@@ -29523,38 +29496,6 @@ namespace FootballEngineUnitTest
                 Assert.AreEqual("Premier League Table", firstGroupOrLeagueTable.Name);
                 Assert.AreEqual(20, firstGroupOrLeagueTable.GroupOrLeagueTableStandings.Count);
                 Assert.IsFalse(footballDataState.IsCacheRefreshed);
-            }
-
-            [TestMethod]
-            public async Task WhenOnlyGroupsOrLeagueTableFootballDataStandingsCached_ThenStandingsReturnedFromCacheButMatchesReturnedFromAPI()
-            {
-                SetupTests();
-
-                var footballDataStandings = JsonSerializer.Deserialize<FootballDataModel>(footballDataStandingsJson);
-
-                footballDataState = new FootballDataState()
-                {
-                    FootballDataStandings = footballDataStandings,
-                    FootballDataMatches = null,
-                    CompetitionStartDate = footballDataStandings.season.startDate,
-                    LastRefreshTime = DateTime.UtcNow,
-                };
-
-                var footballDataService = new FootballDataService(mockHttpAPIClient.Object, footballDataState, footballEngineInput);
-
-                var groupsOrLeagueTable = await footballDataService.GetGroupsOrLeagueTableAsync();
-
-                Assert.IsNotNull(groupsOrLeagueTable);
-
-                var firstGroupOrLeagueTable = groupsOrLeagueTable.FirstOrDefault();
-
-                mockHttpAPIClient.Verify(mock => mock.GetAsync($"competitions/{footballEngineInput.Competition}/standings/"), Times.Never());
-                mockHttpAPIClient.Verify(mock => mock.GetAsync($"competitions/{footballEngineInput.Competition}/matches/"), Times.Once());
-
-                Assert.IsNotNull(firstGroupOrLeagueTable);
-                Assert.AreEqual("Premier League Table", firstGroupOrLeagueTable.Name);
-                Assert.AreEqual(20, firstGroupOrLeagueTable.GroupOrLeagueTableStandings.Count);
-                Assert.IsTrue(footballDataState.IsCacheRefreshed);
             }
 
             [TestMethod]


### PR DESCRIPTION
Tidied Player Position Labels and also ensured that if the competition does not use groups then dont call fixtures API endpoint when obtaining league table.  Only need fixtures if the competition uses groups