### PR TITLE
Fix Form Guide Order in Standings

### DIFF
--- a/FootballEngine/Logic/FixtureAndResultLogic.cs
+++ b/FootballEngine/Logic/FixtureAndResultLogic.cs
@@ -16,9 +16,9 @@ namespace FootballEngine.Services
             _footballEngineInput = footballEngineInput;
         }
 
-        public async Task<List<FixturesAndResultsByDay>> GetFixturesAndResultsByDayAsync()
+        public List<FixturesAndResultsByDay> GetFixturesAndResultsByDay()
         {
-            var fixturesAndResults = await GetFixtureAndResultsAsync();
+            var fixturesAndResults = GetFixtureAndResults();
 
             return fixturesAndResults
                         .GroupBy(x => x.FixtureDate.Date)
@@ -30,9 +30,9 @@ namespace FootballEngine.Services
                         .ToList();
         }
 
-        public async Task<List<GroupOrLeagueTableModel>> GetFixturesAndResultsByGroupsOrLeagueTableAsync(List<GroupOrLeagueTableModel> groups)
+        public List<GroupOrLeagueTableModel> GetFixturesAndResultsByGroupsOrLeagueTable(List<GroupOrLeagueTableModel> groups)
         {
-            var fixturesAndResults = await GetFixtureAndResultsAsync();
+            var fixturesAndResults = GetFixtureAndResults();
 
             var fixturesAndResultsByGroupsOrLeagueTable = fixturesAndResults
                                                             .GroupBy(x => x.GroupOrLeagueTable.Name)
@@ -59,9 +59,9 @@ namespace FootballEngine.Services
             return groups;
         }
 
-        public async Task<FootballShared.Models.Team> GetFixturesAndResultsByTeamAsync(FootballShared.Models.Team team)
+        public FootballShared.Models.Team GetFixturesAndResultsByTeam(FootballShared.Models.Team team)
         {
-            var fixturesAndResults = await GetFixtureAndResultsAsync();
+            var fixturesAndResults = GetFixtureAndResults();
 
             var teamsFixtures = fixturesAndResults
                                     .Where(x => x.HomeTeam.Name == team.Name || x.AwayTeam.Name == team.Name)
@@ -81,7 +81,7 @@ namespace FootballEngine.Services
             return team;
         }
 
-        private async Task<List<FixtureAndResult>> GetFixtureAndResultsAsync()
+        private List<FixtureAndResult> GetFixtureAndResults()
         {
             var fixturesAndResults = _fixturesAndResultsFootballDataModel
                                         .matches

--- a/FootballEngine/Logic/GroupOrLeagueTableLogic.cs
+++ b/FootballEngine/Logic/GroupOrLeagueTableLogic.cs
@@ -50,7 +50,7 @@ namespace FootballEngine.Services
                     GoalsAgainst = x.goalsAgainst,
                     GoalDifference = x.goalDifference,
                     PointsTotal = x.points,
-                    Form = x.form,
+                    Form = string.Join(",", x.form.Split(",").Reverse()) //Reversed order of form guide so form guide order is in ascending order from the earliest game
                 })
                 .ToList(),
             };

--- a/FootballEngine/Logic/Interfaces/IFixtureAndResultLogic.cs
+++ b/FootballEngine/Logic/Interfaces/IFixtureAndResultLogic.cs
@@ -4,8 +4,8 @@ namespace FootballEngine.Logic.Interfaces
 {
     public interface IFixtureAndResultLogic
     {
-        Task<List<FixturesAndResultsByDay>> GetFixturesAndResultsByDayAsync();
-        Task<List<GroupOrLeagueTableModel>> GetFixturesAndResultsByGroupsOrLeagueTableAsync(List<GroupOrLeagueTableModel> groups);
-        Task<FootballShared.Models.Team> GetFixturesAndResultsByTeamAsync(FootballShared.Models.Team team);
+        List<FixturesAndResultsByDay> GetFixturesAndResultsByDay();
+        List<GroupOrLeagueTableModel> GetFixturesAndResultsByGroupsOrLeagueTable(List<GroupOrLeagueTableModel> groups);
+        FootballShared.Models.Team GetFixturesAndResultsByTeam(FootballShared.Models.Team team);
     }
 }

--- a/FootballEngine/Services/FootballDataService.cs
+++ b/FootballEngine/Services/FootballDataService.cs
@@ -72,7 +72,7 @@ namespace FootballEngine.Services
 
             var fixtureAndResultLogic = new FixtureAndResultLogic(footballDataMatches, _footballEngineInput);
 
-            return await fixtureAndResultLogic.GetFixturesAndResultsByTeamAsync(team);
+            return fixtureAndResultLogic.GetFixturesAndResultsByTeam(team);
         }
 
         public async Task<List<FixturesAndResultsByDay>> GetFixturesAndResultsByDaysAsync()
@@ -81,7 +81,7 @@ namespace FootballEngine.Services
 
             var fixtureAndResultLogic = new FixtureAndResultLogic(footballDataMatches, _footballEngineInput);
 
-            return await fixtureAndResultLogic.GetFixturesAndResultsByDayAsync();
+            return fixtureAndResultLogic.GetFixturesAndResultsByDay();
         }
 
         public async Task<List<GroupOrLeagueTableModel>> GetFixturesAndResultsByGroupsAsync(List<GroupOrLeagueTableModel> groupsOrLeagueTable)
@@ -95,7 +95,7 @@ namespace FootballEngine.Services
 
             var fixtureAndResultLogic = new FixtureAndResultLogic(footballDataMatches, _footballEngineInput);
 
-            return await fixtureAndResultLogic.GetFixturesAndResultsByGroupsOrLeagueTableAsync(groupsOrLeagueTable);
+            return fixtureAndResultLogic.GetFixturesAndResultsByGroupsOrLeagueTable(groupsOrLeagueTable);
         }
 
         public async Task<List<FootballShared.Models.Player>> PlayerSearchAsync(PlayerSearchCriteria playerSearchCriteria)


### PR DESCRIPTION
* Reversed order of form guide so form guide order is in ascending order from earliest game
* Changed async function in fixtures and results logic as there is no async function calls in them